### PR TITLE
Fix_env_example 

### DIFF
--- a/contract-deployment-demos/hardhat-demo/.env.example
+++ b/contract-deployment-demos/hardhat-demo/.env.example
@@ -1,2 +1,2 @@
 PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1
-Morph_TESTNET_URL=https://rpc-testnet.morphl2.io
+MORPH_TESTNET_URL=https://rpc-testnet.morphl2.io


### PR DESCRIPTION
According to the hardhat.config.ts file,the env.example should be `MORPH_TESTNET_URL`
<img width="591" alt="image" src="https://github.com/morph-l2/morph-examples/assets/48410497/8441db61-cc56-4f8f-a521-4260781e5a4b">


